### PR TITLE
Feature/cram format multiqc fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Docker image
 By default the workflow pull the docker image from dockerhub. However you can also build docker image locally ::
 
   # Move to containers
-  cd NPM-sample-qc/containers
+  cd containers
   # Build docker image locally
   sh build_npm-sample-qc_docker_image.sh
 

--- a/bin/multiqc_plugins/multiqc_npm/modules/npm_picard_QualityYieldMetrics.py
+++ b/bin/multiqc_plugins/multiqc_npm/modules/npm_picard_QualityYieldMetrics.py
@@ -32,6 +32,15 @@ def parse_reports(self):
                 if fn_search:
                     s_name = os.path.basename(fn_search.group(1).strip('[]'))
                     s_name = self.clean_s_name(s_name, f['root'])
+                    print (s_name)
+                    # To get sample name with '.crma' extension
+                    s_name = os.path.splitext(s_name)[0]
+                    # s_name = os.path.basename(s_name).split('.')[0]
+                    # index = s_name.rfind(".")
+                    # s_name = s_name[:index]
+                    # s_name = os.system(basename "s_name" | cut -d. -f1)
+                    print(s_name, "clean file name with extension such .cram")
+
 
             # Parse metric names and values
             if s_name is not None:

--- a/bin/multiqc_plugins/multiqc_npm/modules/npm_picard_QualityYieldMetrics.py
+++ b/bin/multiqc_plugins/multiqc_npm/modules/npm_picard_QualityYieldMetrics.py
@@ -33,12 +33,8 @@ def parse_reports(self):
                     s_name = os.path.basename(fn_search.group(1).strip('[]'))
                     s_name = self.clean_s_name(s_name, f['root'])
                     print (s_name)
-                    # To get sample name with '.crma' extension
+                    # To get sample name with '.cram' extension
                     s_name = os.path.splitext(s_name)[0]
-                    # s_name = os.path.basename(s_name).split('.')[0]
-                    # index = s_name.rfind(".")
-                    # s_name = s_name[:index]
-                    # s_name = os.system(basename "s_name" | cut -d. -f1)
                     print(s_name, "clean file name with extension such .cram")
 
 

--- a/bin/multiqc_plugins/multiqc_npm/modules/npm_picard_QualityYieldMetrics.py
+++ b/bin/multiqc_plugins/multiqc_npm/modules/npm_picard_QualityYieldMetrics.py
@@ -32,10 +32,9 @@ def parse_reports(self):
                 if fn_search:
                     s_name = os.path.basename(fn_search.group(1).strip('[]'))
                     s_name = self.clean_s_name(s_name, f['root'])
-                    print (s_name)
-                    # To get sample name with '.cram' extension
+                    # Remove file extension
                     s_name = os.path.splitext(s_name)[0]
-                    print(s_name, "clean file name with extension such .cram")
+                    print(s_name, "clean file name without extension")
 
 
             # Parse metric names and values

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -26,6 +26,7 @@ RUN export DEBIAN_FRONTEND="noninteractive" && \
       gnuplot \
       datamash \
       graphviz \
+      vim \
       && rm -rf /var/lib/apt/lists/*
 
     # install conda
@@ -42,6 +43,7 @@ RUN conda env create -f /conda_env.yml
 RUN conda clean -a
 
     # install MultiQC and MultiQC_NPM plugin
-RUN git clone --depth 1 https://github.com/c-BIG/NPM-sample-qc.git
+RUN git clone https://github.com/c-BIG/NPM-sample-qc.git
 WORKDIR /NPM-sample-qc/bin/multiqc_plugins
+RUN git checkout feature/cram-format-multiqc-fix
 RUN python3 setup.py install

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -29,21 +29,21 @@ RUN export DEBIAN_FRONTEND="noninteractive" && \
       vim \
       && rm -rf /var/lib/apt/lists/*
 
-    # install conda
+# install conda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash Miniconda3-latest-Linux-x86_64.sh -b -p /usr/local/conda
 RUN PATH="/usr/local/conda/bin:${PATH}"
 RUN rm Miniconda3-latest-Linux-x86_64.sh
 RUN conda update -n base -c defaults conda
 
+# install AWS CLI
 RUN conda install -c conda-forge -y awscli
 
-    # create conda environment from template
+# create conda environment from template
 RUN conda env create -f /conda_env.yml
 RUN conda clean -a
 
-    # install MultiQC and MultiQC_NPM plugin
-RUN git clone https://github.com/c-BIG/NPM-sample-qc.git
+# install MultiQC and MultiQC_NPM plugin
+RUN git clone --depth 1 https://github.com/c-BIG/NPM-sample-qc.git
 WORKDIR /NPM-sample-qc/bin/multiqc_plugins
-RUN git checkout feature/cram-format-multiqc-fix
 RUN python3 setup.py install

--- a/containers/conda_env.yml
+++ b/containers/conda_env.yml
@@ -2,8 +2,7 @@ name: npm-sample-qc
 channels:
     - bioconda
     - conda-forge
-    - defaults
-channel_priority: strict  
+    - defaults 
 dependencies:
     - python=3.7
     - samtools=1.15

--- a/modules/CollectMultipleMetrics/main.nf
+++ b/modules/CollectMultipleMetrics/main.nf
@@ -12,7 +12,7 @@ process picard_collect_multiple_metrics {
     tuple val(sample), path("${sample}.insert_size_metrics.txt"), emit: insert_size
 
     script:
-    def reference = ref_fasta ? /REFERENCE_SEQUENCE="${ref_fasta}"/ : ''
+    def reference = ref_fasta ? /R="${ref_fasta}"/ : ''
     """
     # program CollectQualityYieldMetrics to get numbers of bases that pass a base quality score 30 threshold
     # program CollectInsertSizeMetrics to get mean insert size

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,7 +81,7 @@ process {
 
         cpus = 1
         disk = '50 GB'
-        memory = { 1.GB * task.attempt }
+        memory = { 3.GB * task.attempt }
 
         publishDir = [
             path: "${params.publishdir}/picard_collect_multiple_metrics",

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
   description = 'Nextflow NPM-sample-qc analysis pipeline, part of the GHIF community.'
   mainScript = 'main.nf'
   nextflowVersion = '!>=23.04.1'
-  version = '0.10.3'
+  version = '0.10.4'
 }
 
 cleanup = true


### PR DESCRIPTION
- Fix processing picard output by multiqc plugin compatible to generate `<sample>_metrics.json` using `compile_metrics.py`
- picard memory resource updated (1 to 3GB) to accomodate reference fasta file 
- Dockerfile fix for testing. 
  - This need to be reverted to previous release command `--depth 1` without checkout to any feature branch after merge to main to generate new docker image