### PR TITLE
update cross_contamination_rate with latest run output metrics.json

### DIFF
--- a/modules/verifybamid2/main.nf
+++ b/modules/verifybamid2/main.nf
@@ -25,7 +25,7 @@ process verifybamid2 {
 
     mix=\$(cut -f7 "${sample}.selfSM"  | grep "FREEMIX" -A 1 | grep -v "FREEMIX")
     round=\$(awk -v var=\$mix 'BEGIN { printf "%.2f", var }' )
-    echo "cross_contamination_rate_round\t"\$round >> "${sample}.selfSM.metrics"
+    echo "cross_contamination_rate\t"\$round >> "${sample}.selfSM.metrics"
     """
 }
 

--- a/tests/NA12878_1000genomes-dragen-3.7.6/output_certified/results/metrics/NA12878.metrics.json
+++ b/tests/NA12878_1000genomes-dragen-3.7.6/output_certified/results/metrics/NA12878.metrics.json
@@ -4,7 +4,7 @@
     },
     "wgs_qc_metrics": {
         "aln_metrics": {
-            "cross_contamination_rate_round": 0.0,
+            "cross_contamination_rate": 0.0,
             "insert_size_std_deviation": 98.7,
             "mad_autosome_coverage": 4,
             "mean_autosome_coverage": 31.08,

--- a/tests/NA12878_1000genomes-dragen-3.7.6/output_certified/results/metrics/NA12878.metrics.json
+++ b/tests/NA12878_1000genomes-dragen-3.7.6/output_certified/results/metrics/NA12878.metrics.json
@@ -4,7 +4,7 @@
     },
     "wgs_qc_metrics": {
         "aln_metrics": {
-            "cross_contamination_rate": 1.8379e-06,
+            "cross_contamination_rate_round": 0.0,
             "insert_size_std_deviation": 98.7,
             "mad_autosome_coverage": 4,
             "mean_autosome_coverage": 31.08,


### PR DESCRIPTION
Include the updated `cross_contamination_rate` (roundoff decimal) test run of NA12878 results`output_certified/results/metrics/NA12878.metrics.json` 